### PR TITLE
Dont give last sync warning if autosync is already enabled

### DIFF
--- a/app/src/ui/app/hints.html
+++ b/app/src/ui/app/hints.html
@@ -68,6 +68,7 @@ padlock.HintsMixin = (superClass) => {
             const daysSinceLastSync = daysPassed(stats.lastSync || stats.firstLaunch);
             if (
                 this.settings.syncConnected &&
+                this.settings.syncAuto == false &&
                 daysSinceLastSync > 7 &&
                 daysPassed(stats.lastSyncReminder || stats.firstLaunch) > 7
             ) {


### PR DESCRIPTION
I use padlock from multiple machines. On some machines I dont
use padlock daily, so I sometimes get the alert that I haven't
synchronized for X days. But I already have autosync enabled,
and padlock is already synchronizing behind the "please enable
autosync" warning dialog.